### PR TITLE
fix: formated cart pricing to two decimal places

### DIFF
--- a/src/components/Cart.jsx
+++ b/src/components/Cart.jsx
@@ -40,7 +40,7 @@ const Cart = () => {
           <div key={`cartproduct${i}`}>
             <h2>{product_order.products.name}</h2>
             <img src={product_order.products.imageURL} width="200px" />
-            <div>{product_order.products.price * product_order.quantity} ₡</div>
+            <div>$ {(product_order.products.price * product_order.quantity).toFixed(2)}</div>
             <button
               onClick={async () => {
                 updateQty(product_order.id, --product_order.quantity);


### PR DESCRIPTION
In the cart.jsx, I added to the .toFixed() method to the product total(Line 43) with the number 2 for the digits. 

docs: [Number.prototype.toFixed()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision)  MDN web Docs